### PR TITLE
Fix deselection on click

### DIFF
--- a/annotate.js
+++ b/annotate.js
@@ -64,7 +64,7 @@ const makeClickHandler = (isHighlight) => {
 // Remove .selected from all elements.
 const deselectAll = () => {
   const selectedComments = document.querySelectorAll('.selected');
-  selectedComments.forEach(selectedComment => selectedComments[i].classList.remove('selected')) 
+  selectedComments.forEach(selectedComment => selectedComment.classList.remove('selected')) 
 }
 
 /**


### PR DESCRIPTION
Just matches for loop to use obj instead of index access. In previous version, check error when firing `deselectAll` with a click anywhere on the page.

Resubmission of #2 